### PR TITLE
Fix robustSolitonDistribution CDF

### DIFF
--- a/util.go
+++ b/util.go
@@ -59,7 +59,7 @@ func robustSolitonDistribution(n int, m int, delta float64) []float64 {
 	for i := 2; i < len(pdf); i++ {
 		pdf[i] = (1 / (float64(i) * float64(i-1)))
 		if i < m {
-			pdf[i] = 1 / (float64(i) * float64(m))
+			pdf[i] += 1 / (float64(i) * float64(m))
 		}
 		if i == m {
 			pdf[i] += math.Log(float64(n)/(float64(m)*delta)) / float64(m)

--- a/util_test.go
+++ b/util_test.go
@@ -70,8 +70,8 @@ func TestRobustSolitonDistribution(t *testing.T) {
 		t.Log("CDF=", cdf)
 	}
 
-	if !almostEqual(cdf[1], .287474) {
-		t.Errorf("CDF[1] = %f, should be 0.287474", cdf[1])
+	if !almostEqual(cdf[1], .137210) {
+		t.Errorf("CDF[1] = %f, should be 0.137210", cdf[1])
 		t.Log("CDF=", cdf)
 	}
 


### PR DESCRIPTION
The robustSolitonDistribution seems missing plus operator. According to Luby's LT codes paper, we need to sum the tau and rho. But current code using only tau in ( i < m ) condition. I think need to add plus operator in line 62.
